### PR TITLE
Add Docstrings to Database Manager Classes

### DIFF
--- a/src/ConfigManager.py
+++ b/src/ConfigManager.py
@@ -2,6 +2,14 @@ from src.StorageManager import StorageManager
 from typing import Any, Dict
 
 class ConfigManager(StorageManager):
+    """
+    Manages configurations stored in the database.
+
+    Each configuration item is stored as a key-value pair in the configs table.
+
+    Values of complex data type are automatically serialized to JSON for storage and
+    deserialized upon retrieval.
+    """
 
     def __init__(self, db_path="config.db") -> None:
         super().__init__(db_path)
@@ -23,14 +31,36 @@ class ConfigManager(StorageManager):
         return "key, value"
     
     def set(self, key: str, value: Any) -> None:
+        """
+        Store or update a configuration value by key.
+
+        key (str): The configuration key.
+
+        value (Any): The value to store. Can be any JSON serializable type.
+        """
         super().set({"key": key, "value": value})
     
     def get(self, key: str, default: Any = None) -> Any:
+        """
+        Retrieve a configuration value by key.
+        
+        key (str): The configuration key to look up.
+
+        default (Any): Value to return if the key is not found. Defaults to None.
+
+        Returns the deserialized value associated with the key, if found,
+        or else default.
+        """
         result = super().get(key, default)
         if result and isinstance(result, dict):
             return result.get("value")
         return default
     
     def get_all(self) -> Dict[str, Any]:
+        """
+        Retrieve all configuration items as a dictionary.
+
+        Keys are mapped to their corresponding deserialized values.
+        """
         rows = super().get_all()
         return {row["key"]: row["value"] for row in rows}

--- a/src/ConsentManager.py
+++ b/src/ConsentManager.py
@@ -1,20 +1,36 @@
 from src.ConfigManager import ConfigManager
 
 class ConsentManager:
+    """
+    Manages user consent for how their files are to be analyzed.
+
+    Consent is stored in the database using ConfigManager under the key "user_consent".
+    This class provides methods to check, request, and enforce consent.
+    """
 
     def __init__(self, db_path="config.db"):
         self.manager = ConfigManager(db_path=db_path)
 
     def has_user_consented(self):
-        #check if user has previously consented to allowing program to run
+        """
+        Check if the user has previously given consent.
+
+        Returns: `True` if the user has consented, `False` otherwise.
+        """
         has_consented = self.manager.get("user_consent") 
         return has_consented is True
 
     def request_consent(self):
+        """
+        Prompt the user for consent to run the program and record the response.
+
+        Accepts "yes", "y" (case-insensitive) as consent. Any other input is treated as denial.
+
+        Returns: `True` if the user has given consent, `False` otherwise.
+        """
         print("Do you give consent to scan your files?")
         answer = input("(yes/no)")
         answer = answer.strip().lower() 
-        #allows yes, y and strips leading/trailing characters from String entered
         consent = answer in ("yes", "y")
 
         self.manager.set("user_consent", consent)
@@ -25,6 +41,13 @@ class ConsentManager:
         return consent
     
     def require_consent(self):
+        """
+        Ensure that the user has given consent before proceeding.
+
+        The return value can be used to control program flow.
+
+        Returns: `True` if the user has previously consented or has now given consent, `False` otherwise.
+        """
         if not self.has_user_consented():
             return self.request_consent()
         return True

--- a/src/StorageManager.py
+++ b/src/StorageManager.py
@@ -5,6 +5,15 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, Generator
 
 class StorageManager(ABC): 
+    """
+    Abstract base class for handling database reads and writes.
+    
+    Defines: set, get, get_all, delete, clear.
+
+    Child classes need to define their table schema and structure, and optionally, override set, get and get_all in order to unpack the return types of it’s base class. (For example, StorageManager’s set() method expects a dict.
+
+    All complex data types (dict, list, bool) are automatically serialized to JSON for storage and deserialized upon retrieval.
+    """
 
     def __init__(self, db_path: str) -> None:
         self.db_path = db_path
@@ -16,6 +25,7 @@ class StorageManager(ABC):
             cursor.execute(self.create_table_query)
 
     def _deserialize_row(self, row_dict: Dict[str, Any]) -> Dict[str, Any]:
+        """Unpack any complex data types from serialized JSON back to its original form."""
         for col, val in row_dict.items():
             try:
                 row_dict[col] = json.loads(val)
@@ -23,11 +33,13 @@ class StorageManager(ABC):
                 row_dict[col] = val
         return row_dict
 
-    # handles the setup and cleanup for database writes and reads
-    # returns a Generator object, ensuring that only one connection is open at once
-
     @contextmanager
     def _get_connection(self) -> Generator[sqlite3.Connection, None, None]:
+        """
+        Manages the setup and cleanup for database reads and writes.
+
+        Returns a Generator object, ensuring that only one connection is open at once.
+        """
         conn = sqlite3.connect(self.db_path)
         try:
             yield conn
@@ -37,12 +49,12 @@ class StorageManager(ABC):
 
     @property
     def columns_list(self) -> list[str]:
+        """Return a list of all columns a table has for use in SQL queries."""
         return [c.strip() for c in self.columns.split(",")]
-    
-    # returns a string of ? placeholders for use in SQL queries
 
     @property
     def placeholders(self) -> str:
+        """Return a string of '?' placeholders for use in SQL queries."""
         return ", ".join("?" for _ in self.columns_list)
 
 
@@ -51,38 +63,50 @@ class StorageManager(ABC):
     @property
     @abstractmethod
     def create_table_query(self) -> str:
+        """Return the create table query for a table for use in SQL queries."""
         pass
 
     @property
     @abstractmethod
     def table_name(self) -> str:
+        """Return the table name of a table for use in SQL queries."""
         pass
 
     @property
     @abstractmethod
     def primary_key(self) -> str:
+        """Return the primary key of a table for use in SQL queries."""
         pass
     
     @property
     @abstractmethod
     def columns(self) -> str:
+        """Return an ordered string of all columns a table has for use in SQL queries."""
         pass
 
     def set(self, row: Dict[str, Any]) -> None:
+        """
+        Insert or update a row, expects a dictionary with column names as keys and values to store. 
+
+        Key-value pairs must be set in the order defined in the child class’s columns property.
+        """
         with self._get_connection() as conn:
             cursor = conn.cursor()
             values = [row[i] for i in self.columns_list]
-            # serialize any values of complex data type
             serialized_values = [
             json.dumps(v) if isinstance(v, (dict, list, bool)) else v
             for v in values
             ]
             query = f"INSERT OR REPLACE INTO {self.table_name} ({self.columns}) VALUES ({self.placeholders})"
             cursor.execute(query, serialized_values)
-                
-    # default param can be used as a fallback, in case the value you're looking for doesn't exist
         
     def get(self, key: str, default: Any = None) -> Dict[str, Any]:
+        """
+        Retrieve a row by primary key.
+        
+        default is an optional fallback value to be used if the key doesn't exist. Defaults to None.
+        """
+
         with self._get_connection() as conn:
             cursor = conn.cursor()
             query = f"SELECT {self.columns} FROM {self.table_name} WHERE {self.primary_key} = ?"
@@ -92,10 +116,13 @@ class StorageManager(ABC):
                 row_dict = dict(zip(self.columns_list, result))
                 return self._deserialize_row(row_dict)
         return default
-
-    #returns true if delete was successful
     
     def delete(self, key: str) -> bool:
+        """ 
+        Delete a row associated with a primary key value from the database.
+
+        Returns `True` if the delete operation is successful.
+        """
         with self._get_connection() as conn:
             cursor = conn.cursor()
             query = f"DELETE FROM {self.table_name} WHERE {self.primary_key} = ?"
@@ -103,6 +130,11 @@ class StorageManager(ABC):
             return cursor.rowcount > 0
     
     def get_all(self) -> list[Dict[str, Any]]:
+        """
+        Retrieve all rows from a table.
+
+        Rows are returned as a list of dicts with deserialized values.
+        """
         with self._get_connection() as conn:
             cursor = conn.cursor()
             query = f"SELECT {self.columns} FROM {self.table_name}"
@@ -115,6 +147,11 @@ class StorageManager(ABC):
         return all_rows
 
     def clear(self) -> None:
+        """
+        Delete all rows from a table.
+
+        Use with caution.
+        """
         with self._get_connection() as conn:
             cursor = conn.cursor()
             query = f"DELETE FROM {self.table_name}"


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

This PR adds docstrings to the database manager classes that were missing them: `StorageManager`, `ConfigManager` and `ConsentManager`. This improves the readability and maintainability of these classes.

Thanks to @joymuesli  for bringing this to my attention! 

**Closes:** #108 

---

## 🔧 Type of Change
- [x] 📚 Documentation added/updated
---

## 🧪 Testing

This PR solely adds documentation and does not affect functionality in any material way. Still, I have:


- [x] Verified that `StorageManager`, `ConfigManager`, and `ConsentManager` methods work as expected.
- [x] Hovered over affected methods in my IDE to ensure their docstrings display correctly.
- [x] Ran existing unit tests to confirm expected behaviour.

As always, you can run: `pytest -v` from the root directory of our project to confirm.

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🔗 Any dependent changes have been merged and published in downstream modules

---

</details>
