### PR TITLE
ZipParser will now account for duplicate folder names in different directories

### DIFF
--- a/src/ZipParser.py
+++ b/src/ZipParser.py
@@ -18,9 +18,7 @@ def parse(path):
                 
                 #Create a root folder, and add it to the dict, accessed via name
                 root = ProjectFolder(file, None)
-                dirs[root.name] = root
-
-                print(root.name)
+                dirs[file.filename] = root
 
                 start = False
 
@@ -28,7 +26,7 @@ def parse(path):
                 if file.is_dir():
                     #determine parent's name
                     parent = file.filename.split("/")
-                    parent = parent[len(parent)-3]
+                    parent = "/".join(parent[:len(parent)-2])+"/"
 
                     #create the object
                     temp = ProjectFolder(file,dirs[parent])
@@ -37,12 +35,12 @@ def parse(path):
                     dirs[parent].subdir.append(temp)
 
                     #create new dict entry for this file
-                    dirs[temp.name] = temp
+                    dirs[file.filename] = temp
 
                 else:
                     #determine parent's name
                     parent = file.filename.split("/")
-                    parent = parent[len(parent)-2]
+                    parent = "/".join(parent[:len(parent)-1])+"/"
 
                     #create the object
                     temp = ProjectFile(file,dirs[parent])


### PR DESCRIPTION
## 📝 Description

> parse() had the potential to run in to an issue with identically named folders when retrieving their parent object from the dict.
> now the keys in the dictionary are the full path of the parent address so this is no longer an issue

**Closes:** #119

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).
> Provide instructions so we can reproduce.

- [x] Ran the test for zip parser
- [x] Made sure output was the same when parsing a zip file before and after changes

---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---