### PR TITLE
Refactor StorageManager get_all() to return a Generator

### DIFF
--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -70,14 +70,14 @@ def test_get_all_and_clear(cleanup_db, sample_project, another_project):
     manager.set(sample_project)
     manager.set(another_project)
     
-    all_projects = manager.get_all()
+    all_projects = list(manager.get_all())
     assert len(all_projects) == 2
     names = [p['name'] for p in all_projects]
     assert "SampleProj" in names and "AnotherProj" in names
     
     # Clear DB and check empty
     manager.clear()
-    assert manager.get_all() == []
+    assert list(manager.get_all()) == []
 
 def test_delete_project(cleanup_db, sample_project):
     manager = ProjectManager(DB_PATH)
@@ -90,7 +90,7 @@ def test_delete_project(cleanup_db, sample_project):
     
     # Make sure it's gone
     assert manager.get(proj_id) is None
-    assert manager.get_all() == []
+    assert list(manager.get_all()) == []
 
 def test_edge_cases_empty_lists_and_none(cleanup_db):
     project = Project(


### PR DESCRIPTION
## 📝 Description

I have refactored the `get_all()` method in `StorageManager` to return a Generator object. This will improve the memory efficiency of our application. Instead of defaulting to loading the whole table in memory, it will now yield items one at a time.

### Example

```Python
pm = ProjectManager()
for project in pm.get_all():
    do_something(project)
```
Alternatively, you may still load the whole table into memory if you need.

```Python
pm = ProjectManager()
all_projects = list(pm.get_all())
```


**Closes:** #115

Thanks to @kaanspgl for the lovely suggestion!

---

## 🔧 Type of Change

- [x] ♻️ Refactoring
- [x] ⚡ Performance improvement

---

## 🧪 Testing

I've had to tweak a couple of tests related to `ProjectManager` as `get_all` was now returning a generator where a list of dicts was expected. To remediate this I've wrapped each returned generator as a list.

Existing tests provide sufficient coverage and pass as expected, but please run `pytest -v` from the root directory of our project to confirm.

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings

---

