### PR TITLE
fix: make load_zip more robust

### DIFF
--- a/src/analyzers/ProjectAnalyzer.py
+++ b/src/analyzers/ProjectAnalyzer.py
@@ -1,5 +1,7 @@
 import os
+import re
 import shutil
+import zipfile
 from src.ZipParser import parse, toString
 from src.analyzers.ProjectMetadataExtractor import ProjectMetadataExtractor
 from src.analyzers.GitRepoAnalyzer import GitRepoAnalyzer
@@ -44,12 +46,21 @@ class ProjectAnalyzer:
             print(f"  - Status: {project.collaboration_status}\n")
             # Will display other variables from Project classes in the future
 
+    def clean_path(self, raw_input: str) -> Path:
+        stripped = raw_input.strip()
+        # Only strip quotes that surround path (so that something like `dylan's.zip` does not break the parser)
+        if (stripped.startswith('"') and stripped.endswith('"')) or \
+        (stripped.startswith("'") and stripped.endswith("'")):
+            stripped = stripped[1:-1]
+        # Remove shell escape backslashes (e.g., "my\ file" -> "my file")
+        unescaped = re.sub(r'\\(.)', r'\1', stripped)
+        return Path(os.path.expanduser(unescaped))
+
     def load_zip(self):
         """Prompts user for ZIP file and parses into folder tree"""
-        zip_path = input("Please enter the path to the zipped folder: ")
-        zip_path = os.path.expanduser(zip_path)
-        while not (os.path.exists(zip_path) and zip_path.endswith(".zip")):
-            zip_path = input("Invalid path or not a zipped file. Please try again: ")
+        zip_path = self.clean_path(input("Please enter the path to the zipped folder: "))
+        while not (os.path.exists(zip_path) and zipfile.is_zipfile(zip_path)):
+            zip_path = self.clean_path(input("Invalid path or not a zipped file. Please try again: "))
 
         self.zip_path = zip_path
         print("Parsing ZIP structure...")


### PR DESCRIPTION
## 📝 Description

I noticed that semicolons in path names were breaking the parser. In the midst of fixing that, I thought I'd try and make the `load_zip` method as robust as possible. As a result I've also added support for quotes/apostrophes that do not surround the entire path name (e.g. `dylan's.zip`) and any special characters that the terminal automatically escapes with a backslash.

I couldn't find anything else allowed in a file name by macOS that would break the parser. However, if you manage to find a way to break it please let me know!



**Closes:** #200 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Test added/updated

---

## 🧪 Testing

I've added quite a few unit tests to make sure common oddities in zip path names are handled correctly.

Also, I've manually tested monstrosities such as:
- /Users/dylanalexander/Desktop/term\ 1\ 2025\:26/d文档\\\%\$\^é🚀\&\*\(\)\!@\#\~yl\"an\'s.zip 

and ensured that they can be loaded correctly.

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally

---
