### PR TITLE
Implement resume item endpoint and add tests

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, UploadFile, File, HTTPException, status
 from pathlib import Path
 from collections import Counter
 import tempfile, shutil
-from src.api.schemas import SkillsListResponse, SkillItem, PortfolioResponse, ConsentResponse, UploadProjectResponse, ProjectsListResponse, ProjectSummary, ProjectDetailResponse, ProjectDetail, TodoResponse
+from src.api.schemas import SkillsListResponse, SkillItem, PortfolioResponse, ConsentResponse, UploadProjectResponse, ProjectsListResponse, ProjectSummary, ProjectDetailResponse, ProjectDetail, TodoResponse, ResumeItemResponse
 from src.analyzers.ProjectAnalyzer import ProjectAnalyzer
 from src.managers.ConfigManager import ConfigManager
 from src.managers.ConsentManager import ConsentManager
@@ -80,9 +80,24 @@ def get_skills_list():
 # The system only currently generates resume insights (As of Jan 18)
 # TODO: Full resume generation then we edit these endpoints
 
-@router.get("/resume/{id}", response_model=TodoResponse)
+@router.get("/resume/{id}", response_model=ResumeItemResponse)
 def get_resume(id: int):
-    return TodoResponse(message="Resume retrieval not implemented yet.")
+    """
+    Retrieve textual information about a project as a resume item.
+    Returns the project's summary and bullet points for use in a resume.
+    """
+    pm = ProjectManager()
+    project = pm.get(id)
+
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found.")
+    
+    return ResumeItemResponse(
+        project_id=project.id,
+        project_name=project.name,
+        summary=project.summary or "",
+        bullets=project.bullets or []
+    )
 
 @router.post("/resume/generate", response_model=TodoResponse)
 def generate_resume():

--- a/src/api/schemas/__init__.py
+++ b/src/api/schemas/__init__.py
@@ -1,5 +1,5 @@
 from .consent import ConsentResponse
-from .resume import TodoResponse
+from .resume import TodoResponse, ResumeItemResponse
 from .portfolio import Portfolio, PortfolioResponse
 from .skills import SkillItem, SkillsListResponse
 from .projects import ProjectSummary, UploadProjectResponse, ProjectsListResponse, ProjectDetail, ProjectDetailResponse

--- a/src/api/schemas/resume.py
+++ b/src/api/schemas/resume.py
@@ -1,5 +1,14 @@
 from pydantic import BaseModel
+from typing import List, Optional
 
 class TodoResponse(BaseModel):
     ok: bool = False
     message: str
+
+class ResumeItemResponse(BaseModel):
+    """Resume item representation of a project with textual information."""
+    ok: bool = True
+    project_id: int
+    project_name: str
+    summary: str = ""
+    bullets: List[str] = []

--- a/tests/test_resume_item_endpoint.py
+++ b/tests/test_resume_item_endpoint.py
@@ -1,0 +1,75 @@
+"""Tests for the resume item endpoint (Requirement #299)"""
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi.testclient import TestClient
+from src.api.api_main import app
+from src.models.Project import Project
+
+
+@pytest.fixture
+def client():
+    """Create a test client for the FastAPI app."""
+    return TestClient(app)
+
+
+def test_get_resume_item_success(client):
+    """Test successful retrieval of a project's resume item information."""
+    # Create a mock project with resume data
+    mock_project = Project(
+        id=1,
+        name="Sample Portfolio Project",
+        summary="Built a full-stack web application",
+        bullets=["Implemented REST API with FastAPI", "Created React frontend", "Deployed to AWS"]
+    )
+    
+    with patch("src.api.routes.ProjectManager") as mock_pm_class:
+        mock_pm = MagicMock()
+        mock_pm_class.return_value = mock_pm
+        mock_pm.get.return_value = mock_project
+        
+        response = client.get("/resume/1")
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["project_id"] == 1
+    assert data["project_name"] == "Sample Portfolio Project"
+    assert data["summary"] == "Built a full-stack web application"
+    assert len(data["bullets"]) == 3
+    assert "Implemented REST API with FastAPI" in data["bullets"]
+
+
+def test_get_resume_item_not_found(client):
+    """Test retrieval when project does not exist."""
+    with patch("src.api.routes.ProjectManager") as mock_pm_class:
+        mock_pm = MagicMock()
+        mock_pm_class.return_value = mock_pm
+        mock_pm.get.return_value = None
+        
+        response = client.get("/resume/999")
+    
+    assert response.status_code == 404
+    assert "Project not found" in response.json()["detail"]
+
+
+def test_get_resume_item_empty_bullets(client):
+    """Test retrieval when project has no bullets yet."""
+    mock_project = Project(
+        id=2,
+        name="Another Project",
+        summary="A project in progress",
+        bullets=[]
+    )
+    
+    with patch("src.api.routes.ProjectManager") as mock_pm_class:
+        mock_pm = MagicMock()
+        mock_pm_class.return_value = mock_pm
+        mock_pm.get.return_value = mock_project
+        
+        response = client.get("/resume/2")
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["bullets"] == []
+    assert data["summary"] == "A project in progress"


### PR DESCRIPTION
## 📝 Description

This PR implements **Requirement #299: Display textual information about a project as a resume item**.

A new REST API endpoint (`GET /resume/{id}`) has been added to retrieve a project's resume information (summary and bullet points). This endpoint leverages the existing `Project` data model and integrates with the `ProjectManager` for database persistence.

The implementation provides programmatic access to resume insights that were previously only available through the CLI (Option 11: "Retrieve Previous Resume Insights"). This enables frontend applications and external tools to consume formatted project achievements for portfolio and resume generation.

**Key additions:**
- New `ResumeItemResponse` Pydantic schema for type-safe API responses
- `/resume/{id}` GET endpoint with proper error handling (404 when project not found)
- Comprehensive test coverage with 3 passing tests

**Dependencies:** No new dependencies added. Uses existing FastAPI, Pydantic, and ProjectManager infrastructure.

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

The implementation was tested with comprehensive unit tests using FastAPI's TestClient:

1. **test_get_resume_item_success**: Verifies successful retrieval of a project's resume data with populated bullets and summary
2. **test_get_resume_item_not_found**: Confirms 404 error handling when requesting a non-existent project
3. **test_get_resume_item_empty_bullets**: Ensures graceful handling when a project has no bullets yet

**Manual verification:**
- All 3 tests passing locally: `pytest tests/test_resume_item_endpoint.py -v`
- Endpoint follows existing API patterns (consistent with `/projects/{id}` endpoint)
- Response model validated against Pydantic schema

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile
