### PR TITLE
Feature/edit info about portfolio items (M2 R27)

### DIFF
--- a/src/services/InsightEditor.py
+++ b/src/services/InsightEditor.py
@@ -33,7 +33,7 @@ class InsightEditor:
                 tech_line = ln.strip()
 
         # Overview block
-        m_overview = re.search(r"\*\*Project Overview:\*\*\n(.+?)(?:\n\n|\n\*\*)", text, flags=re.S)
+        m_overview = re.search(r"\*\*Project Overview:\*\*\n(.+?)(?:\n\n|\n\*\*|$)", text, flags=re.S)
         if m_overview:
             overview = m_overview.group(1).strip()
 

--- a/tests/test_insight_editor.py
+++ b/tests/test_insight_editor.py
@@ -1,0 +1,163 @@
+import pytest
+
+from src.services.InsightEditor import InsightEditor
+from src.analyzers.ProjectAnalyzer import ProjectAnalyzer
+
+
+SAMPLE_ENTRY = """### COSC310-Team-2
+**Role:** Team Contributor (Team of 7) | **Timeline:** 25 days
+**Technologies:** Java, JavaScript, SQL, CSS
+
+**Project Overview:**
+A software solution collaborated with 6 other developers to build over a 25 days period.
+
+**Key Technical Achievements:**
+* Architected a substantial codebase of over 96,890 lines of code.
+* Integrated automated tests to support continuous integration.
+"""
+
+
+# ----------------------------
+# Parse / Build unit tests
+# ----------------------------
+
+def test_parse_portfolio_entry_extracts_fields():
+    parts = InsightEditor.parse_portfolio_entry(SAMPLE_ENTRY)
+
+    # Your parser stores the whole first line, including "### "
+    assert parts.title == "### COSC310-Team-2"
+    assert parts.role_line.strip() == "**Role:** Team Contributor (Team of 7) | **Timeline:** 25 days"
+    assert parts.tech_line.strip() == "**Technologies:** Java, JavaScript, SQL, CSS"
+    assert parts.overview.strip() == "A software solution collaborated with 6 other developers to build over a 25 days period."
+    assert parts.achievements == [
+        "Architected a substantial codebase of over 96,890 lines of code.",
+        "Integrated automated tests to support continuous integration.",
+    ]
+
+
+def test_build_portfolio_entry_contains_all_sections():
+    parts = InsightEditor.parse_portfolio_entry(SAMPLE_ENTRY)
+    rebuilt = InsightEditor.build_portfolio_entry(parts)
+
+    assert "### COSC310-Team-2" in rebuilt
+    assert "**Project Overview:**" in rebuilt
+    assert "**Key Technical Achievements:**" in rebuilt
+    assert "* Architected a substantial codebase" in rebuilt
+    assert "* Integrated automated tests" in rebuilt
+
+
+def test_parse_build_round_trip_is_stable():
+    parts = InsightEditor.parse_portfolio_entry(SAMPLE_ENTRY)
+    rebuilt = InsightEditor.build_portfolio_entry(parts)
+
+    parts2 = InsightEditor.parse_portfolio_entry(rebuilt)
+
+    assert parts2.title == parts.title
+    assert parts2.role_line.strip() == parts.role_line.strip()
+    assert parts2.tech_line.strip() == parts.tech_line.strip()
+    assert parts2.overview.strip() == parts.overview.strip()
+    assert parts2.achievements == parts.achievements
+
+
+def test_build_falls_back_when_no_achievements():
+    parts = InsightEditor.parse_portfolio_entry(SAMPLE_ENTRY)
+    parts.achievements = []
+    rebuilt = InsightEditor.build_portfolio_entry(parts)
+
+    assert "**Key Technical Achievements:**" in rebuilt
+    assert "* Delivered a functional codebase using modern development practices." in rebuilt
+
+
+def test_parse_handles_missing_achievements_section():
+    entry = """### ProjectX
+**Role:** Solo Developer | **Timeline:** 3 days
+**Technologies:** Python
+
+**Project Overview:**
+Just an overview.
+"""
+    parts = InsightEditor.parse_portfolio_entry(entry)
+
+    assert parts.title == "### ProjectX"
+    assert parts.role_line.strip() == "**Role:** Solo Developer | **Timeline:** 3 days"
+    assert parts.tech_line.strip() == "**Technologies:** Python"
+    assert parts.overview.strip() == "Just an overview."
+    assert parts.achievements == []
+
+
+# ----------------------------
+# CLI edit tests (monkeypatch input)
+# ----------------------------
+
+@pytest.fixture
+def analyzer():
+    # Create ProjectAnalyzer instance without running __init__ (avoids DB/config deps)
+    return ProjectAnalyzer.__new__(ProjectAnalyzer)
+
+
+CLI_SAMPLE_ENTRY = """### COSC310-Team-2
+**Role:** Solo Developer | **Timeline:** 0 days
+**Technologies:** Java, JavaScript
+
+**Project Overview:**
+Old overview.
+
+**Key Technical Achievements:**
+* Old achievement
+"""
+
+
+def test_cli_edit_overview(monkeypatch, analyzer):
+    # 3 = overview, then provide new text, then 5 = done
+    inputs = iter(["3", "New overview!", "5"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    updated = analyzer.edit_portfolio_entry_cli(CLI_SAMPLE_ENTRY)
+    parts = InsightEditor.parse_portfolio_entry(updated)
+
+    assert parts.overview == "New overview!"
+
+
+def test_cli_edit_role_line(monkeypatch, analyzer):
+    inputs = iter(["1", "**Role:** Big Dog | **Timeline:** 16 days", "5"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    updated = analyzer.edit_portfolio_entry_cli(CLI_SAMPLE_ENTRY)
+    assert "**Role:** Big Dog | **Timeline:** 16 days" in updated
+
+
+def test_cli_add_achievement(monkeypatch, analyzer):
+    # 4 = achievements menu
+    # 'a' add
+    # then back (empty input) and done
+    inputs = iter([
+        "4",
+        "a",
+        "New achievement",
+        "",
+        "5",
+    ])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    updated = analyzer.edit_portfolio_entry_cli(CLI_SAMPLE_ENTRY)
+    parts = InsightEditor.parse_portfolio_entry(updated)
+
+    assert "New achievement" in parts.achievements
+
+
+def test_cli_delete_achievement(monkeypatch, analyzer):
+    # 4 achievements, 'd' delete, '1' delete first, then back, done
+    inputs = iter([
+        "4",
+        "d",
+        "1",
+        "",
+        "5",
+    ])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    updated = analyzer.edit_portfolio_entry_cli(CLI_SAMPLE_ENTRY)
+    parts = InsightEditor.parse_portfolio_entry(updated)
+
+    assert parts.achievements == ["Delivered a functional codebase using modern development practices."]
+

--- a/tests/test_portfolio_aggregation.py
+++ b/tests/test_portfolio_aggregation.py
@@ -12,13 +12,15 @@ class DummyProject:
         self.portfolio_entry = entry
         self.last_modified = last_modified
 
-def test_retrieve_full_portfolio_aggregates_and_sorts():
+def test_retrieve_full_portfolio_aggregates_and_sorts(monkeypatch):
     analyzer = ProjectAnalyzer(MagicMock(), [], Path("."))
     projects = [
         DummyProject("A", "### A\n**Role:** Team Contributor | **Timeline:** 1 month\n", datetime(2025, 2, 1)),
         DummyProject("B", "### B\n**Role:** Team Contributor | **Timeline:** 2 months\n", datetime(2025, 3, 1)),
         DummyProject("C", "", datetime(2025, 1, 1)),  # empty entry should be skipped
     ]
+
+    monkeypatch.setattr("builtins.input", lambda _: "n")
 
     with patch.object(ProjectAnalyzer, "_get_projects", return_value=projects):
         buf = io.StringIO()


### PR DESCRIPTION
## 📝 Description

This PR adds an interactive menu for editing portfolio/insight entires. Users can manually edit the generated insights after viewing it. Here is a summary of the changes to checkout:
- option 10 now shows the generated portfolio entry first, then prompts user to edit it if they would like to
- option 16 displays the full portfolio first (with edited entries if its been edited), and prompts user to select and edit specific entries if they would like to
- created a method thats reusable as an editing helper in the future. This should be a good method to implement for editing the resume as well if wed like. The method is edit_portfolio_entry_cli in the ProjectAnalyzer. It edits the structured sections of a portfolio entry for now. 
- The InsightEditor.py was added in a new folder (src/services/) that parses and builds portfolio/resume insight entries in a structured way.
- edits should persist through and save. If you retrieve previously generated info or generate the portfolio, the edited sections will persist.

Should be future-proofed well enough for API endpoints.

> List any dependencies that are required for this change.

**Closes:** # (issue number)
Issue #296 
---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).
> Provide instructions so we can reproduce.

- [x] Test A
- Manual testing. ran option 10, edited all entries with that. Ran option 16, edited all entries with that, ran 11 and confirmed that portfolio entries were indeed updated
- [x] Test B
- Full test suite added in tests/test_insight_editor.py to validate parsing and building behavior as well as the CLI editing flows.
- Updated tests/test_portfolio_aggregation.py to handle the new interactive prompt
- to test, run all tests and confirm they pass!!!!

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
