### PR TITLE
Fixed date bug in the frontend

### DIFF
--- a/src/analyzers/ProjectAnalyzer.py
+++ b/src/analyzers/ProjectAnalyzer.py
@@ -572,8 +572,10 @@ class ProjectAnalyzer:
             if size_kb := project_meta.get("total_size_kb"):
                 project.size_kb = int(size_kb)
             if start_date := project_meta.get("start_date"):
+                project.start_date = start_date
                 project.date_created = datetime.strptime(start_date, "%Y-%m-%d")
             if end_date := project_meta.get("end_date"):
+                project.end_date = end_date
                 project.last_modified = datetime.strptime(end_date, "%Y-%m-%d")
 
             project.last_accessed = datetime.now()

--- a/src/api/schemas/projects.py
+++ b/src/api/schemas/projects.py
@@ -99,6 +99,10 @@ class ProjectDetail(BaseModel):
     # Scoring
     resume_score: float = 0.0
 
+    # Project timeline
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+
     # Timestamps
     date_created: Optional[datetime] = None
     last_modified: Optional[datetime] = None

--- a/src/ui/react-app/src/pages/Projects.jsx
+++ b/src/ui/react-app/src/pages/Projects.jsx
@@ -22,9 +22,14 @@ const LANG_COLORS = {
 };
 const lc = (l) => LANG_COLORS[l] ?? LANG_COLORS.default;
 const scoreColor = (s) => s >= 7 ? "#4ade80" : s >= 4 ? "#fbbf24" : "#6b7280";
-const fmt = (iso) => iso
-  ? new Date(iso).toLocaleDateString("en-CA", { year:"numeric", month:"short" })
-  : null;
+const fmt = (iso) => {
+  if (!iso) return null;
+  const [year, month] = iso.split("-");
+  const months = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+  return `${months[Number(month) - 1]} ${year}`;
+};
+
+ 
 
 // ── Language bar ──────────────────────────────────────────────────────────────
 function LangBar({ share = {}, langs = [], height = 4 }) {
@@ -193,6 +198,7 @@ function Tile({ label, value }) {
 // ── Right panel: project detail ───────────────────────────────────────────────
 function ProjectDetail({ project, onDelete, onThumbnailUpload, loading }) {
   const thumbInputRef = useRef();
+  const thumbSrc = project?.thumbnail ? thumbnailUrl(project.thumbnail) : null;
 
   if (loading) {
     return (
@@ -214,6 +220,10 @@ function ProjectDetail({ project, onDelete, onThumbnailUpload, loading }) {
     );
   }
 
+  const dateRange = [fmt(project.date_created), fmt(project.last_modified)]
+  .filter(Boolean)
+  .join(" → ");
+
   const langEntries = Object.entries(project.language_share ?? {}).sort((a, b) => b[1] - a[1]);
   const stack = [...(project.frameworks ?? []), ...(project.skills_used ?? [])];
   const flags = [
@@ -224,8 +234,6 @@ function ProjectDetail({ project, onDelete, onThumbnailUpload, loading }) {
     project.has_test_files && "Tests",
     project.has_readme     && "README",
   ].filter(Boolean);
-  const dateRange = [fmt(project.date_created), fmt(project.last_modified)].filter(Boolean).join(" → ");
-  const thumbSrc = project.thumbnail ? thumbnailUrl(project.thumbnail) : null;
 
   return (
     <div style={{ height:"100%", overflowY:"auto", padding:"28px 32px" }}>


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

This PR fixes a bug that was in our system where it would display incorrect dates. The root cause was the metadata extracted from git/file analysis was not being correctly applied to the Project object/model. As a result, the frontend just relied on default timestamps. the fix included:
- updating ProjectAnalyzer.analyze_metadata to correctly map extracted metadata:
- start_date -> project.date_created
- end_date -> project.last_modified
- ensured extracted timeline persists and is returned through the API
- updated the frontend to consistently use project.date_created and project.last_modified for displaying project timelines

**Closes:** #511 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).
> Provide instructions so we can reproduce.

- [x] Test A
- manually test in the frontend by rm projects.db, uploading your file, and ensuring the dates shown are the proper dates.

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->
<img width="859" height="548" alt="Screenshot 2026-03-28 at 6 13 10 PM" src="https://github.com/user-attachments/assets/5588e99c-3b2d-4537-90de-2bb76753179c" />
<img width="859" height="548" alt="Screenshot 2026-03-28 at 6 13 06 PM" src="https://github.com/user-attachments/assets/7fbdd481-6b02-477a-a5ac-38ee49d7f9b9" />

</details>
