### PR TITLE
Open Web Portfolio Into a New Page

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -1,7 +1,7 @@
 from typing import Any, List, Optional
 
 from fastapi import APIRouter, UploadFile, File, HTTPException, status, Depends
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, HTMLResponse
 from pathlib import Path
 from collections import Counter
 import tempfile, shutil
@@ -81,14 +81,17 @@ def _build_portfolio_project(project) -> PortfolioProject:
 
 def _build_portfolio_report(report) -> PortfolioReport:
     projects = [_build_portfolio_project(p) for p in (report.projects or [])]
+    mode = getattr(report, "portfolio_mode", "private") or "private"
+    public_url = f"http://localhost:8000/public/portfolio/{report.id}" if mode == "public" else None
     return PortfolioReport(
         id=report.id,
         title=report.title,
         date_created=report.date_created,
         sort_by=report.sort_by,
         notes=report.notes,
-        portfolio_mode=getattr(report, "portfolio_mode", "private") or "private",
+        portfolio_mode=mode,
         portfolio_published_at=getattr(report, "portfolio_published_at", None),
+        public_url=public_url,
         projects=projects,
     )
 
@@ -996,3 +999,37 @@ def publish_portfolio(id: int):
     report.portfolio_published_at = datetime.now()
     report_manager.update_report(report)
     return PortfolioPublishResponse(ok=True, portfolio=_build_portfolio_report(report), message="Portfolio published.")
+
+
+@router.get("/public/portfolio/{id}", response_class=HTMLResponse)
+def public_portfolio_page(id: int):
+    """Serve a publicly accessible HTML portfolio page. No auth required; only works when portfolio_mode is 'public'."""
+    import jinja2
+    from pathlib import Path as _Path
+
+    report_manager = ReportManager()
+    report = report_manager.get_report(id)
+    if not report or getattr(report, "portfolio_mode", "private") != "public":
+        raise HTTPException(status_code=404, detail="Portfolio not found or not public.")
+    _require_report_kind(report, "portfolio")
+
+    portfolio = _build_portfolio_report(report)
+
+    published_at = None
+    if portfolio.portfolio_published_at:
+        published_at = portfolio.portfolio_published_at.strftime("%B %d, %Y")
+
+    visible_projects = [
+        p for p in portfolio.projects
+        if not (p.portfolio_customizations or {}).get("is_hidden", False)
+    ]
+
+    templates_dir = _Path(__file__).parent / "templates"
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader(str(templates_dir)), autoescape=True)
+    template = env.get_template("public_portfolio.html")
+    html = template.render(
+        title=portfolio.title or "Portfolio",
+        published_at=published_at,
+        projects=visible_projects,
+    )
+    return HTMLResponse(content=html)

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -1032,6 +1032,14 @@ def public_portfolio_page(id: int):
             filename = Path(proj.thumbnail).name
             thumbnail_urls[p.project_name] = f"http://localhost:8000/thumbnails/{filename}"
 
+    all_badges = build_badge_progress(list(project_manager.get_all()))
+    badges_by_project: dict = {}
+    for badge in all_badges.get("badges", []):
+        if badge.get("earned"):
+            name = (badge.get("project") or {}).get("name", "")
+            if name:
+                badges_by_project.setdefault(name, []).append(badge)
+
     templates_dir = _Path(__file__).parent / "templates"
     env = jinja2.Environment(loader=jinja2.FileSystemLoader(str(templates_dir)), autoescape=True)
     template = env.get_template("public_portfolio.html")
@@ -1040,5 +1048,6 @@ def public_portfolio_page(id: int):
         published_at=published_at,
         projects=visible_projects,
         thumbnail_urls=thumbnail_urls,
+        badges_by_project=badges_by_project,
     )
     return HTMLResponse(content=html)

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -1024,6 +1024,14 @@ def public_portfolio_page(id: int):
         if not (p.portfolio_customizations or {}).get("is_hidden", False)
     ]
 
+    project_manager = ProjectManager()
+    thumbnail_urls = {}
+    for p in visible_projects:
+        proj = project_manager.get_by_name(p.project_name)
+        if proj and getattr(proj, "thumbnail", None):
+            filename = Path(proj.thumbnail).name
+            thumbnail_urls[p.project_name] = f"http://localhost:8000/thumbnails/{filename}"
+
     templates_dir = _Path(__file__).parent / "templates"
     env = jinja2.Environment(loader=jinja2.FileSystemLoader(str(templates_dir)), autoescape=True)
     template = env.get_template("public_portfolio.html")
@@ -1031,5 +1039,6 @@ def public_portfolio_page(id: int):
         title=portfolio.title or "Portfolio",
         published_at=published_at,
         projects=visible_projects,
+        thumbnail_urls=thumbnail_urls,
     )
     return HTMLResponse(content=html)

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -82,7 +82,8 @@ def _build_portfolio_project(project) -> PortfolioProject:
 def _build_portfolio_report(report) -> PortfolioReport:
     projects = [_build_portfolio_project(p) for p in (report.projects or [])]
     mode = getattr(report, "portfolio_mode", "private") or "private"
-    public_url = f"http://localhost:8000/public/portfolio/{report.id}" if mode == "public" else None
+    token = getattr(report, "public_token", None)
+    public_url = f"http://localhost:8000/public/portfolio/{token}" if mode == "public" and token else None
     return PortfolioReport(
         id=report.id,
         title=report.title,
@@ -91,6 +92,7 @@ def _build_portfolio_report(report) -> PortfolioReport:
         notes=report.notes,
         portfolio_mode=mode,
         portfolio_published_at=getattr(report, "portfolio_published_at", None),
+        public_token=token,
         public_url=public_url,
         projects=projects,
     )
@@ -982,8 +984,26 @@ def unpublish_portfolio(id: int):
 
     report.portfolio_mode = "private"
     report.portfolio_published_at = None
+    report.public_token = None
     report_manager.update_report(report)
     return PortfolioPublishResponse(ok=True, portfolio=_build_portfolio_report(report), message="Portfolio moved to private mode.")
+
+
+def _generate_portfolio_slug(title: str, report_manager: ReportManager, exclude_id: Optional[int] = None) -> str:
+    import re
+    base = re.sub(r"[^a-z0-9]+", "-", (title or "portfolio").lower()).strip("-") or "portfolio"
+    existing_tokens = {
+        getattr(r, "public_token", None)
+        for r in report_manager.list_reports()
+        if r.id != exclude_id
+    }
+    if base not in existing_tokens:
+        return base
+    for _ in range(10):
+        candidate = f"{base}-{uuid4().hex[:4]}"
+        if candidate not in existing_tokens:
+            return candidate
+    return f"{base}-{uuid4().hex[:8]}"
 
 
 @router.post("/portfolio/{id}/publish", response_model=PortfolioPublishResponse, dependencies=[Depends(require_consent)])
@@ -997,19 +1017,25 @@ def publish_portfolio(id: int):
 
     report.portfolio_mode = "public"
     report.portfolio_published_at = datetime.now()
+    if not report.public_token:
+        report.public_token = _generate_portfolio_slug(report.title, report_manager, exclude_id=report.id)
     report_manager.update_report(report)
     return PortfolioPublishResponse(ok=True, portfolio=_build_portfolio_report(report), message="Portfolio published.")
 
 
-@router.get("/public/portfolio/{id}", response_class=HTMLResponse)
-def public_portfolio_page(id: int):
+@router.get("/public/portfolio/{token}", response_class=HTMLResponse)
+def public_portfolio_page(token: str):
     """Serve a publicly accessible HTML portfolio page. No auth required; only works when portfolio_mode is 'public'."""
     import jinja2
     from pathlib import Path as _Path
 
     report_manager = ReportManager()
-    report = report_manager.get_report(id)
-    if not report or getattr(report, "portfolio_mode", "private") != "public":
+    all_reports = report_manager.list_reports()
+    report = next(
+        (r for r in all_reports if getattr(r, "public_token", None) == token and r.portfolio_mode == "public"),
+        None,
+    )
+    if not report:
         raise HTTPException(status_code=404, detail="Portfolio not found or not public.")
     _require_report_kind(report, "portfolio")
 

--- a/src/api/schemas/portfolio.py
+++ b/src/api/schemas/portfolio.py
@@ -45,6 +45,7 @@ class PortfolioReport(BaseModel):
     projects: List[PortfolioProject] = Field(default_factory=list)
     portfolio_mode: str = "private"
     portfolio_published_at: Optional[datetime] = None
+    public_url: Optional[str] = None
 
 
 class PortfolioGenerateRequest(BaseModel):

--- a/src/api/schemas/portfolio.py
+++ b/src/api/schemas/portfolio.py
@@ -45,6 +45,7 @@ class PortfolioReport(BaseModel):
     projects: List[PortfolioProject] = Field(default_factory=list)
     portfolio_mode: str = "private"
     portfolio_published_at: Optional[datetime] = None
+    public_token: Optional[str] = None
     public_url: Optional[str] = None
 
 

--- a/src/api/templates/public_portfolio.html
+++ b/src/api/templates/public_portfolio.html
@@ -147,6 +147,23 @@
     color: #8b949e;
   }
 
+  .badge-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 10px;
+  }
+
+  .badge-chip {
+    background: #2d2a1e;
+    border: 1px solid #6e5a1e;
+    color: #e3c84a;
+    border-radius: 20px;
+    padding: 2px 10px;
+    font-size: 0.78rem;
+    font-weight: 600;
+  }
+
   .footer {
     margin-top: 56px;
     padding-top: 20px;
@@ -175,6 +192,14 @@
     {% set details = project.portfolio_details %}
     <div class="card">
       <h2>{{ project.project_name | e }}</h2>
+
+      {% if badges_by_project.get(project.project_name) %}
+      <div class="badge-chips">
+        {% for b in badges_by_project.get(project.project_name) %}
+        <span class="badge-chip">🏅 {{ b.label | e }}</span>
+        {% endfor %}
+      </div>
+      {% endif %}
 
       <div class="role-line">
         {% if details.role %}

--- a/src/api/templates/public_portfolio.html
+++ b/src/api/templates/public_portfolio.html
@@ -1,0 +1,230 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>{{ title | e }} — Portfolio</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+
+  body {
+    font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    background: #0d1117;
+    color: #e6edf3;
+    margin: 0;
+    padding: 0;
+    line-height: 1.6;
+  }
+
+  .page-wrap {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 48px 24px 80px;
+  }
+
+  .header {
+    margin-bottom: 40px;
+    border-bottom: 1px solid #21262d;
+    padding-bottom: 28px;
+  }
+
+  .header h1 {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0 0 8px;
+    letter-spacing: -0.02em;
+  }
+
+  .header .meta {
+    color: #8b949e;
+    font-size: 0.9rem;
+  }
+
+  .badge {
+    display: inline-block;
+    background: #1f6feb22;
+    color: #58a6ff;
+    border: 1px solid #1f6feb55;
+    border-radius: 20px;
+    padding: 2px 10px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    vertical-align: middle;
+    margin-left: 10px;
+  }
+
+  .card {
+    background: #161b22;
+    border: 1px solid #21262d;
+    border-radius: 10px;
+    padding: 22px 24px;
+    margin-bottom: 16px;
+    transition: border-color 0.15s;
+  }
+
+  .card:hover {
+    border-color: #30363d;
+  }
+
+  .card h2 {
+    font-size: 1.15rem;
+    font-weight: 600;
+    margin: 0 0 6px;
+    color: #e6edf3;
+  }
+
+  .card .role-line {
+    color: #8b949e;
+    font-size: 0.88rem;
+    margin: 0 0 14px;
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  .card .role-line span {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .tech-pill {
+    display: inline-block;
+    background: #21262d;
+    color: #c9d1d9;
+    border-radius: 4px;
+    padding: 1px 7px;
+    font-size: 0.78rem;
+    margin-right: 4px;
+    margin-bottom: 10px;
+  }
+
+  .card .overview {
+    font-size: 0.93rem;
+    color: #c9d1d9;
+    margin: 0 0 14px;
+  }
+
+  .card h3 {
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: #8b949e;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    margin: 14px 0 8px;
+  }
+
+  .card ul {
+    margin: 0 0 0 18px;
+    padding: 0;
+    color: #c9d1d9;
+    font-size: 0.92rem;
+  }
+
+  .card ul li {
+    margin-bottom: 5px;
+  }
+
+  .contributors {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 4px;
+  }
+
+  .contributor-chip {
+    background: #21262d;
+    border: 1px solid #30363d;
+    border-radius: 20px;
+    padding: 3px 10px;
+    font-size: 0.8rem;
+    color: #c9d1d9;
+  }
+
+  .contributor-chip .role-tag {
+    color: #8b949e;
+  }
+
+  .footer {
+    margin-top: 56px;
+    padding-top: 20px;
+    border-top: 1px solid #21262d;
+    color: #484f58;
+    font-size: 0.8rem;
+    text-align: center;
+  }
+</style>
+</head>
+<body>
+  <div class="page-wrap">
+
+    <div class="header">
+      <h1>{{ title | e }} <span class="badge">Public</span></h1>
+      {% if published_at %}
+      <p class="meta">Published {{ published_at }}</p>
+      {% endif %}
+    </div>
+
+    {% if not projects %}
+      <p style="color:#8b949e;">No projects in this portfolio.</p>
+    {% endif %}
+
+    {% for project in projects %}
+    {% set details = project.portfolio_details %}
+    <div class="card">
+      <h2>{{ project.project_name | e }}</h2>
+
+      <div class="role-line">
+        {% if details.role %}
+        <span>{{ details.role | e }}</span>
+        {% endif %}
+        {% if details.timeline and details.timeline != "N/A" %}
+        <span>{{ details.timeline | e }}</span>
+        {% endif %}
+      </div>
+
+      {% if details.technologies %}
+      <div>
+        {% for tech in details.technologies.split(", ") %}
+        <span class="tech-pill">{{ tech | e }}</span>
+        {% endfor %}
+      </div>
+      {% endif %}
+
+      {% set overview = project.portfolio_customizations.get("custom_overview", "") or details.overview %}
+      {% if overview %}
+      <p class="overview">{{ overview | e }}</p>
+      {% endif %}
+
+      {% set achievements = project.portfolio_customizations.get("custom_achievements", []) or details.achievements %}
+      {% if achievements %}
+      <h3>Key Contributions</h3>
+      <ul>
+        {% for achievement in achievements %}
+        <li>{{ achievement | e }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+
+      {% if details.contributor_roles %}
+      <h3>Contributors</h3>
+      <div class="contributors">
+        {% for contributor in details.contributor_roles %}
+        <span class="contributor-chip">
+          {{ contributor.name | e }}{% if contributor.role %} <span class="role-tag">— {{ contributor.role | e }}</span>{% endif %}
+        </span>
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
+    {% endfor %}
+
+    <div class="footer">
+      Generated by 200 OK Hired
+    </div>
+
+  </div>
+</body>
+</html>

--- a/src/api/templates/public_portfolio.html
+++ b/src/api/templates/public_portfolio.html
@@ -193,6 +193,11 @@
       </div>
       {% endif %}
 
+      {% if thumbnail_urls[project.project_name] is defined %}
+      <img src="{{ thumbnail_urls[project.project_name] }}" alt="{{ project.project_name | e }} thumbnail"
+           style="width:100%;max-height:220px;object-fit:cover;border-radius:6px;margin-bottom:14px;" />
+      {% endif %}
+
       {% set overview = project.portfolio_customizations.get("custom_overview", "") or details.overview %}
       {% if overview %}
       <p class="overview">{{ overview | e }}</p>

--- a/src/managers/ReportManager.py
+++ b/src/managers/ReportManager.py
@@ -48,7 +48,7 @@ class ReportManager(StorageManager):
 
     @property
     def columns(self) -> str:
-        return "id, title, date_created, sort_by, notes, report_kind, portfolio_mode, portfolio_published_at"
+        return "id, title, date_created, sort_by, notes, report_kind, portfolio_mode, portfolio_published_at, public_token"
 
     def create_report(self, report: Report) -> int:
         """
@@ -100,7 +100,8 @@ class ReportManager(StorageManager):
                 datetime.fromisoformat(report_dict["portfolio_published_at"])
                 if report_dict.get("portfolio_published_at")
                 else None
-            )
+            ),
+            public_token=report_dict.get("public_token"),
         )
 
     def set_title(self, id: int, title: str) -> bool:
@@ -221,7 +222,8 @@ class ReportManager(StorageManager):
                     datetime.fromisoformat(row_dict["portfolio_published_at"])
                     if row_dict.get("portfolio_published_at")
                     else None
-                )
+                ),
+                public_token=row_dict.get("public_token"),
             ))
 
         return reports
@@ -299,3 +301,5 @@ class ReportManager(StorageManager):
                 cursor.execute("ALTER TABLE reports ADD COLUMN portfolio_mode TEXT DEFAULT 'private'")
             if "portfolio_published_at" not in existing:
                 cursor.execute("ALTER TABLE reports ADD COLUMN portfolio_published_at TEXT")
+            if "public_token" not in existing:
+                cursor.execute("ALTER TABLE reports ADD COLUMN public_token TEXT")

--- a/src/models/Report.py
+++ b/src/models/Report.py
@@ -22,6 +22,7 @@ class Report:
     report_kind: Literal["resume", "portfolio"] = "resume"
     portfolio_mode: Literal["private", "public"] = "private"
     portfolio_published_at: Optional[datetime] = None
+    public_token: Optional[str] = None
 
     def __post_init__(self):
         """Sort projects and catch case where user left title empty after initialization"""
@@ -99,6 +100,7 @@ class Report:
             "report_kind": self.report_kind,
             "portfolio_mode": self.portfolio_mode,
             "portfolio_published_at": self.portfolio_published_at.isoformat() if self.portfolio_published_at else None,
+            "public_token": self.public_token,
         }
 
 # from_dict intentionally omitted, ReportManager will handle retrieval of Reports

--- a/src/ui/react-app/src/pages/PortfolioPage.jsx
+++ b/src/ui/react-app/src/pages/PortfolioPage.jsx
@@ -635,6 +635,26 @@ function PortfolioPage() {
                 >
                   {isPrivateMode ? "🔒 Private" : "🔓 Public"}
                 </button>
+                {isPublicMode && portfolio?.public_url && (
+                  <a
+                    href={portfolio.public_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{
+                      fontSize: 12,
+                      color: "#58a6ff",
+                      textDecoration: "none",
+                      background: "#1f6feb22",
+                      border: "1px solid #1f6feb55",
+                      borderRadius: 6,
+                      padding: "3px 10px",
+                      whiteSpace: "nowrap",
+                    }}
+                    title="Open public portfolio page"
+                  >
+                    Open public page ↗
+                  </a>
+                )}
                 {isPublicMode && (
                   <>
                     <input

--- a/src/ui/react-app/src/pages/PortfolioPage.jsx
+++ b/src/ui/react-app/src/pages/PortfolioPage.jsx
@@ -598,6 +598,13 @@ function PortfolioPage() {
             <button onClick={handleCopyPortfolioHtml} disabled={loading || !portfolio} style={{ marginLeft: 10 }}>
               Copy Portfolio HTML
             </button>
+            <button
+              disabled={!portfolio?.public_url || isPrivateMode}
+              style={{ marginLeft: 10 }}
+              onClick={() => window.open(portfolio.public_url, "_blank", "noopener,noreferrer")}
+            >
+              Open Public Page ↗
+            </button>
           </div>
           <div style={{background:"#333", height:"1px"}}></div>
           </div>
@@ -635,26 +642,6 @@ function PortfolioPage() {
                 >
                   {isPrivateMode ? "🔒 Private" : "🔓 Public"}
                 </button>
-                {isPublicMode && portfolio?.public_url && (
-                  <a
-                    href={portfolio.public_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style={{
-                      fontSize: 12,
-                      color: "#58a6ff",
-                      textDecoration: "none",
-                      background: "#1f6feb22",
-                      border: "1px solid #1f6feb55",
-                      borderRadius: 6,
-                      padding: "3px 10px",
-                      whiteSpace: "nowrap",
-                    }}
-                    title="Open public portfolio page"
-                  >
-                    Open public page ↗
-                  </a>
-                )}
                 {isPublicMode && (
                   <>
                     <input

--- a/src/ui/react-app/src/tests/PortfolioPage.test.jsx
+++ b/src/ui/react-app/src/tests/PortfolioPage.test.jsx
@@ -53,6 +53,8 @@ describe("PortfolioPage web portfolio",()=>{
       portfolio:{
         title:"Portfolio Report",
         portfolio_mode:"public",
+        public_url:"http://localhost:8000/public/portfolio/my-report",
+        public_token:"my-report",
         projects:[
           {
             project_name:"Proj A",
@@ -238,5 +240,59 @@ describe("PortfolioPage web portfolio",()=>{
     });
 
     expect(screen.queryByText(/Polyglot • 65%/i)).not.toBeInTheDocument();
+  });
+
+  it("Open Public Page button is disabled before a portfolio is generated",async()=>{
+    render(<PortfolioPage />);
+    await waitFor(()=>screen.getByText("Saved Reports"));
+
+    const btn = screen.getByRole("button", { name: /open public page/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it("Open Public Page button is disabled when portfolio is private",async()=>{
+    const user=userEvent.setup();
+    await generatePortfolio(user);
+
+    // toggle to private — unpublishPortfolio returns portfolio_mode:"private", no public_url
+    unpublishPortfolio.mockResolvedValueOnce({
+      portfolio:{
+        title:"Portfolio Report",
+        portfolio_mode:"private",
+        public_url:null,
+        public_token:null,
+        projects:[{
+          project_name:"Proj A",
+          summary:"",
+          bullets:[],
+          collaboration_status:"individual",
+          languages:["Python"],
+          portfolio_customizations:{},
+          portfolio_details:{ role:"", timeline:"", overview:"", achievements:[], contributor_roles:[] },
+        }],
+      },
+    });
+
+    await user.click(screen.getByRole("button",{name:/toggle portfolio mode/i}));
+    await waitFor(()=>expect(screen.getByTestId("portfolio-mode-badge")).toHaveTextContent(/private/i));
+
+    expect(screen.getByRole("button",{name:/open public page/i})).toBeDisabled();
+  });
+
+  it("Open Public Page button is enabled and opens the correct URL when public",async()=>{
+    const openSpy = vi.spyOn(window, "open").mockImplementation(()=>{});
+    const user=userEvent.setup();
+    await generatePortfolio(user);
+
+    const btn = await screen.findByRole("button",{name:/open public page/i});
+    expect(btn).not.toBeDisabled();
+
+    await user.click(btn);
+    expect(openSpy).toHaveBeenCalledWith(
+      "http://localhost:8000/public/portfolio/my-report",
+      "_blank",
+      "noopener,noreferrer"
+    );
+    openSpy.mockRestore();
   });
 });

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1274,6 +1274,7 @@ def test_publish_and_unpublish_portfolio(client, monkeypatch):
     class FakeReportManager:
         def get_report(self, id): return report if id == 14 else None
         def update_report(self, updated): return True
+        def list_reports(self): return []
 
     monkeypatch.setattr(routes, "ConsentManager", FakeConsentManager)
     monkeypatch.setattr(routes, "ReportManager", FakeReportManager)
@@ -1287,6 +1288,185 @@ def test_publish_and_unpublish_portfolio(client, monkeypatch):
     assert unpub.status_code == 200
     assert unpub.json()["portfolio"]["portfolio_mode"] == "private"
     assert unpub.json()["portfolio"]["portfolio_published_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# Public portfolio page — slug token, HTML route
+# ---------------------------------------------------------------------------
+
+def test_publish_generates_slug_token(client, monkeypatch):
+    """Publish sets a slug derived from the report title, not a numeric ID."""
+    class FakeConsentManager:
+        def has_user_consented(self): return True
+
+    report = Report(id=20, title="My SWE Portfolio", date_created=datetime(2025,1,1),
+                    sort_by="resume_score", projects=[], notes=None, report_kind="portfolio")
+
+    class FakeReportManager:
+        def get_report(self, id): return report if id == 20 else None
+        def update_report(self, updated): return True
+        def list_reports(self): return []
+
+    monkeypatch.setattr(routes, "ConsentManager", FakeConsentManager)
+    monkeypatch.setattr(routes, "ReportManager", FakeReportManager)
+
+    res = client.post("/portfolio/20/publish")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["portfolio"]["public_token"] == "my-swe-portfolio"
+    assert data["portfolio"]["public_url"] == "http://localhost:8000/public/portfolio/my-swe-portfolio"
+
+
+def test_publish_token_stable_on_republish(client, monkeypatch):
+    """Re-publishing keeps the existing token instead of generating a new one."""
+    class FakeConsentManager:
+        def has_user_consented(self): return True
+
+    report = Report(id=21, title="Stable", date_created=datetime(2025,1,1),
+                    sort_by="resume_score", projects=[], notes=None, report_kind="portfolio")
+    report.public_token = "already-set"
+
+    class FakeReportManager:
+        def get_report(self, id): return report if id == 21 else None
+        def update_report(self, updated): return True
+        def list_reports(self): return []
+
+    monkeypatch.setattr(routes, "ConsentManager", FakeConsentManager)
+    monkeypatch.setattr(routes, "ReportManager", FakeReportManager)
+
+    res = client.post("/portfolio/21/publish")
+    assert res.status_code == 200
+    assert res.json()["portfolio"]["public_token"] == "already-set"
+
+
+def test_unpublish_clears_token(client, monkeypatch):
+    """Unpublishing clears public_token so the old URL stops working."""
+    class FakeConsentManager:
+        def has_user_consented(self): return True
+
+    report = Report(id=22, title="R", date_created=datetime(2025,1,1),
+                    sort_by="resume_score", projects=[], notes=None, report_kind="portfolio")
+    report.portfolio_mode = "public"
+    report.public_token = "my-report"
+
+    class FakeReportManager:
+        def get_report(self, id): return report if id == 22 else None
+        def update_report(self, updated): return True
+
+    monkeypatch.setattr(routes, "ConsentManager", FakeConsentManager)
+    monkeypatch.setattr(routes, "ReportManager", FakeReportManager)
+
+    res = client.post("/portfolio/22/unpublish")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["portfolio"]["public_token"] is None
+    assert data["portfolio"]["public_url"] is None
+
+
+def test_public_portfolio_page_returns_html(client, monkeypatch):
+    """GET /public/portfolio/{token} returns 200 HTML for a public portfolio."""
+    report = Report(id=23, title="Public Port", date_created=datetime(2025,1,1),
+                    sort_by="resume_score", projects=[], notes=None, report_kind="portfolio")
+    report.portfolio_mode = "public"
+    report.public_token = "public-port"
+
+    class FakeReportManager:
+        def list_reports(self): return [report]
+
+    class FakeProjectManager:
+        def get_by_name(self, name): return None
+        def get_all(self): return iter([])
+
+    monkeypatch.setattr(routes, "ReportManager", FakeReportManager)
+    monkeypatch.setattr(routes, "ProjectManager", FakeProjectManager)
+    monkeypatch.setattr(routes, "build_badge_progress", lambda projects: {"badges": []})
+
+    res = client.get("/public/portfolio/public-port")
+    assert res.status_code == 200
+    assert "text/html" in res.headers["content-type"]
+    assert "Public Port" in res.text
+    assert "Public" in res.text
+
+
+def test_public_portfolio_page_404_when_private(client, monkeypatch):
+    """GET /public/portfolio/{token} returns 404 if the portfolio is private."""
+    report = Report(id=24, title="Private", date_created=datetime(2025,1,1),
+                    sort_by="resume_score", projects=[], notes=None, report_kind="portfolio")
+    report.portfolio_mode = "private"
+    report.public_token = "private-token"
+
+    class FakeReportManager:
+        def list_reports(self): return [report]
+
+    monkeypatch.setattr(routes, "ReportManager", FakeReportManager)
+
+    res = client.get("/public/portfolio/private-token")
+    assert res.status_code == 404
+
+
+def test_public_portfolio_page_404_unknown_token(client, monkeypatch):
+    """GET /public/portfolio/{token} returns 404 for an unrecognised token."""
+    class FakeReportManager:
+        def list_reports(self): return []
+
+    monkeypatch.setattr(routes, "ReportManager", FakeReportManager)
+
+    res = client.get("/public/portfolio/does-not-exist")
+    assert res.status_code == 404
+
+
+def test_generate_portfolio_slug_basic():
+    """Slug is lowercased and special characters become hyphens."""
+    class FakeRM:
+        def list_reports(self): return []
+
+    slug = routes._generate_portfolio_slug("My SWE Portfolio!", FakeRM())
+    assert slug == "my-swe-portfolio"
+
+
+def test_generate_portfolio_slug_collision():
+    """When the base slug is taken, a 4-char suffix is appended."""
+    existing = Report(id=1, title="X", date_created=datetime(2025,1,1),
+                      sort_by="resume_score", projects=[], report_kind="portfolio")
+    existing.public_token = "my-portfolio"
+
+    class FakeRM:
+        def list_reports(self): return [existing]
+
+    slug = routes._generate_portfolio_slug("My Portfolio", FakeRM(), exclude_id=99)
+    assert slug.startswith("my-portfolio-")
+    assert len(slug) == len("my-portfolio-") + 4
+
+
+def test_public_portfolio_page_hides_hidden_projects(client, monkeypatch):
+    """Projects marked is_hidden are excluded from the public page."""
+    from src.models.ReportProject import ReportProject, PortfolioDetails
+
+    visible = ReportProject(project_name="Visible", portfolio_details=PortfolioDetails())
+    hidden = ReportProject(project_name="Hidden", portfolio_details=PortfolioDetails(),
+                           portfolio_customizations={"is_hidden": True})
+
+    report = Report(id=25, title="Port", date_created=datetime(2025,1,1),
+                    sort_by="resume_score", projects=[visible, hidden],
+                    notes=None, report_kind="portfolio")
+    report.portfolio_mode = "public"
+    report.public_token = "hide-test"
+
+    class FakeReportManager:
+        def list_reports(self): return [report]
+
+    class FakeProjectManager:
+        def get_by_name(self, name): return None
+        def get_all(self): return iter([])
+
+    monkeypatch.setattr(routes, "ReportManager", FakeReportManager)
+    monkeypatch.setattr(routes, "ProjectManager", FakeProjectManager)
+    monkeypatch.setattr(routes, "build_badge_progress", lambda projects: {"badges": []})
+
+    res = client.get("/public/portfolio/hide-test")
+    assert res.status_code == 200
+    assert "Visible" in res.text
+    assert "Hidden" not in res.text
 
 
 def test_patch_report_project_report_not_found(client, monkeypatch):


### PR DESCRIPTION
## 📝 Description

This PR implements a live, shareable web page for published portfolios, served directly from the local backend.

## New Features
1. Public portfolio page: `GET /public/portfolio/{slug}` serves a standalone HTML page. Returns 404 if the portfolio is private or the slug doesn't exist.
2. Slug-based URLs: publishing generates a readable slug from the report title to use used for the portfolio's URL. (e.g. `my-swe-portfolio`). The slug is stable. Re-publishing won't change it. Appends a short suffix (e.g. `ef2f`) if there's a collision.
3. Unpublish invalidates the URL: Setting the portfolio to private immediately breaks the old link.
4. Thumbnails: if a project has a thumbnail uploaded, it appears on the public page.
5. Badge chips: earned badges are displayed per project, matching the in-app portfolio view.
6. "Open Public Page" button: added to the portfolio action bar. Disabled when no portfolio is loaded or the portfolio is private.

## Technical Changes
1. `public_token` field added to Report model, `ReportManager` (with auto-migration), and `PortfolioReport` schema.
2. `public_url` field on `PortfolioReport` computed from the token when mode is set to public.
3. Jinja2 HTML template at `src/api/templates/public_portfolio.html`


**Closes:** #534 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Manual Testing Guide

Create or select a report, then click Generate Web Portfolio. Ensure the report is set to Public. The `Open Public Page ↗` button in the action bar should now be enabled. Click it to open the public page in a browser and verify your projects, badges, and thumbnails (if any) appear correctly. Copy the URL from the browser. It should read something like `http://localhost:8000/public/portfolio/my-report-title`. Click the mode badge to switch to Private and refresh the public URL. It should return a 404. Toggle back to public and confirm the page is accessible again under a new URL.

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

## New "Open Public Page" Option

<img width="1680" height="964" alt="Screenshot 2026-04-02 at 3 36 54 PM" src="https://github.com/user-attachments/assets/0c4bab31-1995-46da-a680-e211e319426e" />

## New Public Portfolio Page

<img width="1674" height="968" alt="Screenshot 2026-04-02 at 3 32 31 PM" src="https://github.com/user-attachments/assets/6b17a944-565a-4355-a84c-89159dabf6b3" />
