### PR TITLE
Fixes made to Skill Detection, Documentation Score

### DIFF
--- a/src/analyzers/SkillAnalyzer.py
+++ b/src/analyzers/SkillAnalyzer.py
@@ -701,9 +701,15 @@ class SkillAnalyzer:
         }
 
         # --- Documentation habits ---
+        # Composite: 30% has_readme, 40% readme keyword quality, 30% comment ratio
         comment_ratio = overall.get("comment_ratio", 0.0)
-        # e.g. 0.05 is minimal, 0.2+ is solid
-        doc_score = min(1.0, comment_ratio / 0.2)
+        has_readme, readme_keywords = self._analyze_readme()
+        readme_score = 0.30 if has_readme else 0.0
+        # 5 keywords = full quality score; capped at 0.40
+        readme_quality_score = min(0.40, (len(readme_keywords) / 5) * 0.40) if has_readme else 0.0
+        # 20%+ comment ratio = full comment score; capped at 0.30
+        comment_score = min(0.30, (comment_ratio / 0.2) * 0.30)
+        doc_score = readme_score + readme_quality_score + comment_score
         doc_level = self._level_from_score(doc_score)
 
         doc_dim = {
@@ -711,6 +717,8 @@ class SkillAnalyzer:
             "level": doc_level,
             "raw": {
                 "comment_ratio": comment_ratio,
+                "has_readme": has_readme,
+                "readme_keywords": readme_keywords,
             },
         }
 

--- a/src/analyzers/SkillAnalyzer.py
+++ b/src/analyzers/SkillAnalyzer.py
@@ -7,7 +7,7 @@ import os
 
 from src.FileCategorizer import FileCategorizer
 
-from .skill_models import Evidence, SkillProfileItem, TAXONOMY, KNOWN_FRAMEWORKS
+from .skill_models import Evidence, SkillProfileItem, KNOWN_FRAMEWORKS
 from .skill_patterns import DEP_TO_SKILL, SNIPPET_PATTERNS, KNOWN_CONFIG_HINTS
 from .skill_proficiency import ProficiencyEstimator
 from .code_metrics_analyzer import CodeMetricsAnalyzer, CodeFileAnalysis
@@ -89,21 +89,44 @@ README_KEYWORDS_WHITELIST: Set[str] = {
 }
 
 DEPENDENCY_FILES: Set[str] = {
+    # JavaScript / Node
     "package.json",
     "package-lock.json",
     "pnpm-lock.yaml",
     "yarn.lock",
+    # Python
     "requirements.txt",
     "pyproject.toml",
     "Pipfile",
     "Pipfile.lock",
     "environment.yml",
     "poetry.lock",
+    "setup.py",
+    "setup.cfg",
+    # Java
     "pom.xml",
     "build.gradle",
     "build.gradle.kts",
+    # Go
     "go.mod",
+    # Rust
+    "Cargo.toml",
+    # Ruby
+    "Gemfile",
+    # Dart / Flutter
+    "pubspec.yaml",
+    # C++
+    "CMakeLists.txt",
+    "conanfile.txt",
+    "conanfile.py",
+    # .NET (exact-name files; *.csproj matched via DEPENDENCY_EXTENSIONS)
+    "packages.config",
+    "nuget.config",
 }
+
+# File extensions (no dot) for dep files that can't use exact-name matching
+# e.g. MyProject.csproj — name varies per project but extension is fixed
+DEPENDENCY_EXTENSIONS: Set[str] = {"csproj"}
 
 
 class SkillAnalyzer:
@@ -475,21 +498,9 @@ class SkillAnalyzer:
 
         max_loc = max(loc_per_lang.values()) or 1
 
-        # TAXONOMY might be a dict or a set; handle both cases
-        is_tax_dict = isinstance(TAXONOMY, dict)
-
         for lang, loc in loc_per_lang.items():
             rel_weight = loc / max_loc
-
-            if is_tax_dict:
-                entry = TAXONOMY.get(lang) or TAXONOMY.get(lang.lower())
-                if isinstance(entry, dict):
-                    skill_name = entry.get("canonical_name") or entry.get("name") or lang
-                else:
-                    skill_name = str(entry) if entry is not None else lang
-            else:
-                # TAXONOMY is a set or something non-dict; just use the language name
-                skill_name = lang
+            skill_name = lang
 
             evidence.append(
                 Evidence(
@@ -511,7 +522,8 @@ class SkillAnalyzer:
             if not path.is_file():
                 continue
 
-            if path.name not in DEPENDENCY_FILES:
+            file_ext = path.suffix.lstrip(".").lower()
+            if path.name not in DEPENDENCY_FILES and file_ext not in DEPENDENCY_EXTENSIONS:
                 continue   # ignore random docs
 
             try:
@@ -522,9 +534,16 @@ class SkillAnalyzer:
             for item in DEP_TO_SKILL:
                 pattern, skill = item[0], item[1]
                 allowed_files = item[2] if len(item) > 2 else None
-                # Skip this pattern if it doesn't apply to the current file type
-                if allowed_files is not None and path.name not in allowed_files:
-                    continue
+                # Skip this pattern if it doesn't apply to the current file type.
+                # allowed_files entries starting with "*." are extension patterns (e.g. "*.csproj").
+                if allowed_files is not None:
+                    name_match = path.name in allowed_files
+                    ext_match = any(
+                        f.startswith("*.") and file_ext == f[2:]
+                        for f in allowed_files
+                    )
+                    if not name_match and not ext_match:
+                        continue
                 if hasattr(pattern, "search"):
                     match = pattern.search(text)
                 else:

--- a/src/analyzers/SkillAnalyzer.py
+++ b/src/analyzers/SkillAnalyzer.py
@@ -38,7 +38,6 @@ BUILD_TOOL_SKILLS: Set[str] = {
     "Rollup",
     "Parcel",
     "CMake",
-    "Make",
 }
 
 FRONTEND_FRAMEWORKS: Set[str] = {
@@ -520,7 +519,12 @@ class SkillAnalyzer:
             except OSError:
                 continue
 
-            for pattern, skill in self._iter_pattern_pairs(DEP_TO_SKILL):
+            for item in DEP_TO_SKILL:
+                pattern, skill = item[0], item[1]
+                allowed_files = item[2] if len(item) > 2 else None
+                # Skip this pattern if it doesn't apply to the current file type
+                if allowed_files is not None and path.name not in allowed_files:
+                    continue
                 if hasattr(pattern, "search"):
                     match = pattern.search(text)
                 else:

--- a/src/analyzers/skill_models.py
+++ b/src/analyzers/skill_models.py
@@ -38,17 +38,21 @@ NON_LANGUAGE_TAXONOMY: Set[str] = {
     ".NET", "ASP.NET", "Spring", "Django", "Flask", "FastAPI", "Express",
     "Unity", "Unreal Engine", "Qt", "Electron",
 
+    # Frontend / UI
+    "Tailwind", "Bootstrap", "Redux",
+
     # Data & ML
     "NumPy", "Pandas", "scikit-learn", "PyTorch", "TensorFlow", "Matplotlib",
 
     # Tooling
-    "Docker", "Kubernetes", "Git", "Maven", "Gradle", "NPM", "Yarn", "PNPM", "Vite",
-    "Webpack", "Babel", "ESLint", "Prettier", "Jest", "Mocha", "PyTest", "JUnit",
-    "CMake", "Make", "Conan", "Poetry", "Pip", "Pipenv",
+    "Docker", "Kubernetes", "Git", "Maven", "Gradle", "Vite",
+    "Webpack", "Jest", "Mocha", "PyTest", "JUnit",
+    "CMake", "Conan", "Poetry",
 
     # Cloud/DB
     "AWS", "GCP", "Azure", "Firebase",
     "PostgreSQL", "MySQL", "SQLite", "MongoDB", "Redis",
+    "Hibernate",
 
     # Testing/Other
     "Playwright", "Cypress", "Selenium", "Vitest",
@@ -61,6 +65,7 @@ KNOWN_FRAMEWORKS: Set[str] = {
     "Django", "Flask", "FastAPI", "Spring", "ASP.NET",
     "Node.js", "Express",
     "Unity", "Unreal Engine",
+    "Tailwind", "Bootstrap", "Redux",
 }
 
 

--- a/src/analyzers/skill_models.py
+++ b/src/analyzers/skill_models.py
@@ -22,8 +22,8 @@ class Evidence:
 class SkillProfileItem:
     skill: str
     evidence: List[Evidence]
-    proficiency: List[Evidence]
-    confidence: List[Evidence]
+    proficiency: float
+    confidence: float
     # Extra resume-friendly fields
     primary_language: Optional[str] = None
     total_loc: int = 0
@@ -40,6 +40,12 @@ NON_LANGUAGE_TAXONOMY: Set[str] = {
 
     # Frontend / UI
     "Tailwind", "Bootstrap", "Redux",
+
+    # Mobile / Cross-platform
+    "Flutter",
+
+    # Ruby
+    "Rails", "RSpec",
 
     # Data & ML
     "NumPy", "Pandas", "scikit-learn", "PyTorch", "TensorFlow", "Matplotlib",
@@ -66,6 +72,7 @@ KNOWN_FRAMEWORKS: Set[str] = {
     "Node.js", "Express",
     "Unity", "Unreal Engine",
     "Tailwind", "Bootstrap", "Redux",
+    "Flutter", "Rails",
 }
 
 

--- a/src/analyzers/skill_patterns.py
+++ b/src/analyzers/skill_patterns.py
@@ -3,64 +3,72 @@ Regex patterns and config-names for skill extraction.
 """
 
 import re
-from typing import List, Tuple
+from typing import List, Optional, Set, Tuple
 
+# Dependency file groups — patterns are only matched against their relevant files
+JS_DEP_FILES: Set[str] = {"package.json", "package-lock.json", "pnpm-lock.yaml", "yarn.lock"}
+PYTHON_DEP_FILES: Set[str] = {"requirements.txt", "pyproject.toml", "Pipfile", "Pipfile.lock", "environment.yml", "poetry.lock"}
+JAVA_DEP_FILES: Set[str] = {"pom.xml", "build.gradle", "build.gradle.kts"}
+DOTNET_DEP_FILES: Set[str] = {"*.csproj", "packages.config", "nuget.config"}
+GO_DEP_FILES: Set[str] = {"go.mod"}
+CPP_DEP_FILES: Set[str] = {"CMakeLists.txt", "conanfile.txt", "conanfile.py"}
+ALL_DEP_FILES: Optional[Set[str]] = None  # None = match any dependency file
 
-DEP_TO_SKILL: List[Tuple[re.Pattern, str]] = [
-    # JS/TS
-    (re.compile(r"react(-dom)?", re.I), "React"),
-    (re.compile(r"\bnext\b", re.I), "Next.js"),
-    (re.compile(r"angular", re.I), "Angular"),
-    (re.compile(r"vue", re.I), "Vue"),
-    (re.compile(r"svelte", re.I), "Svelte"),
-    (re.compile(r"(node|express)\b", re.I), "Node.js"),
-    (re.compile(r"typescript", re.I), "TypeScript"),
-    (re.compile(r"webpack", re.I), "Webpack"),
-    (re.compile(r"vite", re.I), "Vite"),
-    (re.compile(r"babel", re.I), "Babel"),
-    (re.compile(r"eslint", re.I), "ESLint"),
-    (re.compile(r"prettier", re.I), "Prettier"),
-    (re.compile(r"jest", re.I), "Jest"),
-    (re.compile(r"vitest", re.I), "Vitest"),
-    (re.compile(r"cypress", re.I), "Cypress"),
-    (re.compile(r"playwright", re.I), "Playwright"),
-    # Python
-    (re.compile(r"django", re.I), "Django"),
-    (re.compile(r"flask", re.I), "Flask"),
-    (re.compile(r"fastapi", re.I), "FastAPI"),
-    (re.compile(r"pandas", re.I), "Pandas"),
-    (re.compile(r"numpy", re.I), "NumPy"),
-    (re.compile(r"(scikit-learn|sklearn)", re.I), "scikit-learn"),
-    (re.compile(r"matplotlib", re.I), "Matplotlib"),
-    (re.compile(r"(pytest|py\.test)", re.I), "PyTest"),
-    (re.compile(r"(pipenv|poetry)", re.I), "Poetry"),
-    # Java
-    (re.compile(r"(spring|spring-boot)", re.I), "Spring"),
-    (re.compile(r"junit", re.I), "JUnit"),
-    (re.compile(r"maven", re.I), "Maven"),
-    (re.compile(r"gradle", re.I), "Gradle"),
+# Each entry: (pattern, skill, allowed_dep_files)
+# allowed_dep_files=None means the pattern runs against all dependency files.
+DEP_TO_SKILL: List[Tuple[re.Pattern, str, Optional[Set[str]]]] = [
+    # JS/TS — only look in JS package files
+    (re.compile(r"\"react(-dom)?\"", re.I), "React", JS_DEP_FILES),
+    (re.compile(r"\"next\"", re.I), "Next.js", JS_DEP_FILES),
+    (re.compile(r"\"@angular/core\"", re.I), "Angular", JS_DEP_FILES),
+    (re.compile(r"\"vue\"", re.I), "Vue", JS_DEP_FILES),
+    (re.compile(r"\"svelte\"", re.I), "Svelte", JS_DEP_FILES),
+    (re.compile(r"\"express\"", re.I), "Node.js", JS_DEP_FILES),
+    (re.compile(r"\"typescript\"", re.I), "TypeScript", JS_DEP_FILES),
+    (re.compile(r"\"webpack\"", re.I), "Webpack", JS_DEP_FILES),
+    (re.compile(r"\"vite\"", re.I), "Vite", JS_DEP_FILES),
+    (re.compile(r"\"jest\"", re.I), "Jest", JS_DEP_FILES),
+    (re.compile(r"\"vitest\"", re.I), "Vitest", JS_DEP_FILES),
+    (re.compile(r"\"cypress\"", re.I), "Cypress", JS_DEP_FILES),
+    (re.compile(r"\"@playwright/", re.I), "Playwright", JS_DEP_FILES),
+    (re.compile(r"\"tailwindcss\"", re.I), "Tailwind", JS_DEP_FILES),
+    (re.compile(r"\"bootstrap\"", re.I), "Bootstrap", JS_DEP_FILES),
+    (re.compile(r"\"(@reduxjs/toolkit|redux)\"", re.I), "Redux", JS_DEP_FILES),
+    # Python — only look in Python dep files
+    (re.compile(r"\bdjango\b", re.I), "Django", PYTHON_DEP_FILES),
+    (re.compile(r"\bflask\b", re.I), "Flask", PYTHON_DEP_FILES),
+    (re.compile(r"\bfastapi\b", re.I), "FastAPI", PYTHON_DEP_FILES),
+    (re.compile(r"\bpandas\b", re.I), "Pandas", PYTHON_DEP_FILES),
+    (re.compile(r"\bnumpy\b", re.I), "NumPy", PYTHON_DEP_FILES),
+    (re.compile(r"(scikit-learn|sklearn)", re.I), "scikit-learn", PYTHON_DEP_FILES),
+    (re.compile(r"\bmatplotlib\b", re.I), "Matplotlib", PYTHON_DEP_FILES),
+    (re.compile(r"(pytest|py\.test)", re.I), "PyTest", PYTHON_DEP_FILES),
+    (re.compile(r"\bpoetry\b", re.I), "Poetry", PYTHON_DEP_FILES),
+    (re.compile(r"\bplaywright\b", re.I), "Playwright", PYTHON_DEP_FILES),
+    # Java — only look in Java build files
+    (re.compile(r"spring(-boot)?", re.I), "Spring", JAVA_DEP_FILES),
+    (re.compile(r"\bjunit\b", re.I), "JUnit", JAVA_DEP_FILES),
+    (re.compile(r"\bhibernate\b", re.I), "Hibernate", JAVA_DEP_FILES),
     # C++ / Tooling
-    (re.compile(r"cmake", re.I), "CMake"),
-    (re.compile(r"conan", re.I), "Conan"),
+    (re.compile(r"\bcmake\b", re.I), "CMake", CPP_DEP_FILES),
+    (re.compile(r"\bconan\b", re.I), "Conan", CPP_DEP_FILES),
     # .NET
-    (re.compile(r"(asp\.?net|entityframework|efcore)", re.I), "ASP.NET"),
-    (re.compile(r"(microsoft\.net|dotnet)", re.I), ".NET"),
-    # Game
-    (re.compile(r"unity", re.I), "Unity"),
-    (re.compile(r"(unreal|ue[45]?)", re.I), "Unreal Engine"),
-    # DB / Cloud
-    (re.compile(r"postgres", re.I), "PostgreSQL"),
-    (re.compile(r"mysql", re.I), "MySQL"),
-    (re.compile(r"sqlite", re.I), "SQLite"),
-    (re.compile(r"mongodb", re.I), "MongoDB"),
-    (re.compile(r"redis", re.I), "Redis"),
-    (re.compile(r"aws", re.I), "AWS"),
-    (re.compile(r"(gcp|google-?cloud)", re.I), "GCP"),
-    (re.compile(r"azure", re.I), "Azure"),
-    (re.compile(r"firebase", re.I), "Firebase"),
+    (re.compile(r"(asp\.?net|entityframework|efcore)", re.I), "ASP.NET", DOTNET_DEP_FILES),
+    (re.compile(r"(microsoft\.net|dotnet)", re.I), ".NET", DOTNET_DEP_FILES),
+    # Game — Unity/Unreal are never listed in standard dep files; detected via config/snippet only
+    # DB / Cloud — these are safe to match broadly since names are distinctive
+    (re.compile(r"\bpostgres(ql)?\b", re.I), "PostgreSQL", ALL_DEP_FILES),
+    (re.compile(r"\bmysql\b", re.I), "MySQL", ALL_DEP_FILES),
+    (re.compile(r"\bsqlite\b", re.I), "SQLite", ALL_DEP_FILES),
+    (re.compile(r"\bmongodb\b", re.I), "MongoDB", ALL_DEP_FILES),
+    (re.compile(r"\bredis\b", re.I), "Redis", ALL_DEP_FILES),
+    (re.compile(r"\baws\b", re.I), "AWS", ALL_DEP_FILES),
+    (re.compile(r"google-cloud-", re.I), "GCP", ALL_DEP_FILES),
+    (re.compile(r"\bazure\b", re.I), "Azure", ALL_DEP_FILES),
+    (re.compile(r"\bfirebase\b", re.I), "Firebase", ALL_DEP_FILES),
     # Other
-    (re.compile(r"graphql", re.I), "GraphQL"),
-    (re.compile(r"grpc", re.I), "gRPC"),
+    (re.compile(r"\bgraphql\b", re.I), "GraphQL", ALL_DEP_FILES),
+    (re.compile(r"\bgrpc\b", re.I), "gRPC", ALL_DEP_FILES),
 ]
 
 
@@ -94,4 +102,9 @@ KNOWN_CONFIG_HINTS: List[Tuple[re.Pattern, str, str]] = [
     (re.compile(r"^CMakeLists\.txt$"), "CMake", "build_tool"),
     (re.compile(r"^Dockerfile$"), "Docker", "build_tool"),
     (re.compile(r"^docker-compose\..*"), "Docker", "build_tool"),
+    # Unity: ProjectSettings folder or .unity scene files are definitive signals
+    (re.compile(r"^ProjectSettings$", re.I), "Unity", "framework_convention"),
+    (re.compile(r"\.unity$", re.I), "Unity", "framework_convention"),
+    # Unreal: .uproject file is the canonical signal
+    (re.compile(r"\.uproject$", re.I), "Unreal Engine", "framework_convention"),
 ]

--- a/src/analyzers/skill_patterns.py
+++ b/src/analyzers/skill_patterns.py
@@ -9,11 +9,14 @@ from typing import List, Optional, Set, Tuple
 # Only package.json for framework detection — lock files list transitive deps and cause false positives
 JS_DEP_FILES: Set[str] = {"package.json"}
 JS_LOCK_FILES: Set[str] = {"package-lock.json", "pnpm-lock.yaml", "yarn.lock"}
-PYTHON_DEP_FILES: Set[str] = {"requirements.txt", "pyproject.toml", "Pipfile", "Pipfile.lock", "environment.yml", "poetry.lock"}
+PYTHON_DEP_FILES: Set[str] = {"requirements.txt", "pyproject.toml", "Pipfile", "Pipfile.lock", "environment.yml", "poetry.lock", "setup.py", "setup.cfg"}
 JAVA_DEP_FILES: Set[str] = {"pom.xml", "build.gradle", "build.gradle.kts"}
 DOTNET_DEP_FILES: Set[str] = {"*.csproj", "packages.config", "nuget.config"}
 GO_DEP_FILES: Set[str] = {"go.mod"}
 CPP_DEP_FILES: Set[str] = {"CMakeLists.txt", "conanfile.txt", "conanfile.py"}
+RUBY_DEP_FILES: Set[str] = {"Gemfile"}
+DART_DEP_FILES: Set[str] = {"pubspec.yaml"}
+RUST_DEP_FILES: Set[str] = {"Cargo.toml"}
 ALL_DEP_FILES: Optional[Set[str]] = None  # None = match any dependency file
 
 # Each entry: (pattern, skill, allowed_dep_files)
@@ -51,6 +54,11 @@ DEP_TO_SKILL: List[Tuple[re.Pattern, str, Optional[Set[str]]]] = [
     (re.compile(r"spring(-boot)?", re.I), "Spring", JAVA_DEP_FILES),
     (re.compile(r"\bjunit\b", re.I), "JUnit", JAVA_DEP_FILES),
     (re.compile(r"\bhibernate\b", re.I), "Hibernate", JAVA_DEP_FILES),
+    # Ruby
+    (re.compile(r"\brails\b", re.I), "Rails", RUBY_DEP_FILES),
+    (re.compile(r"\brspec\b", re.I), "RSpec", RUBY_DEP_FILES),
+    # Dart / Flutter
+    (re.compile(r"\bflutter\b", re.I), "Flutter", DART_DEP_FILES),
     # C++ / Tooling
     (re.compile(r"\bcmake\b", re.I), "CMake", CPP_DEP_FILES),
     (re.compile(r"\bconan\b", re.I), "Conan", CPP_DEP_FILES),
@@ -78,7 +86,8 @@ SNIPPET_PATTERNS: List[Tuple[re.Pattern, str, str]] = [
     # imports / includes
     (re.compile(r"^\s*import\s+.*\s+from\s+['\"]react['\"]", re.M), "React", "import_statement"),
     (re.compile(r"^\s*import\s+.*\s+from\s+['\"]next['\"]", re.M), "Next.js", "import_statement"),
-    (re.compile(r"^\s*from\s+django\s+import\s+", re.M), "Django", "import_statement"),
+    (re.compile(r"^\s*from\s+django(\.\w+)*\s+import\s+", re.M), "Django", "import_statement"),
+    (re.compile(r"^\s*import\s+django\b", re.M), "Django", "import_statement"),
     (re.compile(r"^\s*import\s+flask", re.M), "Flask", "import_statement"),
     (re.compile(r"^\s*from\s+fastapi\s+import\s+", re.M), "FastAPI", "import_statement"),
     (re.compile(r"#include\s*<gtest/gtest\.h>"), "C++", "import_statement"),

--- a/src/analyzers/skill_patterns.py
+++ b/src/analyzers/skill_patterns.py
@@ -6,7 +6,9 @@ import re
 from typing import List, Optional, Set, Tuple
 
 # Dependency file groups — patterns are only matched against their relevant files
-JS_DEP_FILES: Set[str] = {"package.json", "package-lock.json", "pnpm-lock.yaml", "yarn.lock"}
+# Only package.json for framework detection — lock files list transitive deps and cause false positives
+JS_DEP_FILES: Set[str] = {"package.json"}
+JS_LOCK_FILES: Set[str] = {"package-lock.json", "pnpm-lock.yaml", "yarn.lock"}
 PYTHON_DEP_FILES: Set[str] = {"requirements.txt", "pyproject.toml", "Pipfile", "Pipfile.lock", "environment.yml", "poetry.lock"}
 JAVA_DEP_FILES: Set[str] = {"pom.xml", "build.gradle", "build.gradle.kts"}
 DOTNET_DEP_FILES: Set[str] = {"*.csproj", "packages.config", "nuget.config"}

--- a/src/analyzers/skill_proficiency.py
+++ b/src/analyzers/skill_proficiency.py
@@ -90,6 +90,8 @@ class ProficiencyEstimator:
         framework_like = {
             "Django", "Flask", "FastAPI", "React", "Next.js", "Angular", "Vue", "Svelte",
             "Spring", ".NET", "ASP.NET", "Express", "Unity", "Unreal Engine",
+            "Tailwind", "Bootstrap", "Redux", "Hibernate",
+            "Rails", "Flutter",
         }
         if skill in framework_like:
             hits = 0
@@ -99,11 +101,12 @@ class ProficiencyEstimator:
             return [0.0, 0.45, 0.62, 0.75][min(3, hits)]
 
         # ---- Testing tools (PyTest/JUnit/Jest/etc.) ----
-        if skill in {"PyTest", "JUnit", "Jest", "Vitest", "Cypress", "Playwright"}:
-            py_tests = stats.get("python", {}).get("test_files", 0)
-            if py_tests >= 3:
+        if skill in {"PyTest", "JUnit", "Jest", "Vitest", "Cypress", "Playwright", "Mocha", "RSpec"}:
+            # Use overall test file count — language-agnostic
+            overall_test_files = stats.get("overall", {}).get("num_test_files", 0)
+            if overall_test_files >= 3:
                 return 0.72
-            if py_tests >= 1:
+            if overall_test_files >= 1:
                 return 0.55
             return 0.4 if any(e.source in ("dependency", "test_framework") for e in evidence) else 0.2
 

--- a/src/config/ignored_directories.yml
+++ b/src/config/ignored_directories.yml
@@ -40,6 +40,10 @@ ignored_dirs:
   - env
   - virtualenv
 
+  # R dependency management (equivalent of node_modules)
+  - renv
+  - packrat
+
   # IDE / project metadata
   - .idea
   - .vscode

--- a/src/config/languages.yml
+++ b/src/config/languages.yml
@@ -63,7 +63,7 @@ languages:
     extensions: [m, mat, sce]
 
   Objective-C:
-    extensions: [m, mm, h]
+    extensions: [mm]
 
   Perl:
     extensions: [pl, pm]

--- a/src/generators/ResumeInsightsGenerator.py
+++ b/src/generators/ResumeInsightsGenerator.py
@@ -313,7 +313,7 @@ class ResumeInsightsGenerator:
 
         doc_score = getattr(self.project, "documentation_habits_score", 0)
         if doc_score > 0:
-            skill_evidence["Documentation"] = f"documentation score {doc_score:.1f}/100"
+            skill_evidence["Documentation"] = f"documentation score {doc_score * 100:.0f}/100"
 
         contributions = getattr(self.project, "individual_contributions", {}) or {}
         if isinstance(contributions, dict):

--- a/src/ui/react-app/src/pages/Projects.jsx
+++ b/src/ui/react-app/src/pages/Projects.jsx
@@ -226,7 +226,7 @@ function ProjectDetail({ project, onDelete, onThumbnailUpload, loading }) {
   .join(" → ");
 
   const langEntries = Object.entries(project.language_share ?? {}).sort((a, b) => b[1] - a[1]);
-  const stack = [...(project.frameworks ?? []), ...(project.skills_used ?? [])];
+  const stack = [...new Set([...(project.frameworks ?? []), ...(project.skills_used ?? [])])];
   const flags = [
     project.has_dockerfile && "Docker",
     project.has_database   && "Database",

--- a/tests/test_resume_insight_generator.py
+++ b/tests/test_resume_insight_generator.py
@@ -162,12 +162,12 @@ def test_skill_evidence_map_provides_direct_skill_backing():
     }
     gen.project.total_loc = 1500
     gen.project.test_file_ratio = 0.25
-    gen.project.documentation_habits_score = 80.0
+    gen.project.documentation_habits_score = 0.8
 
     skill_evidence = gen._build_skill_evidence_map()
 
     assert skill_evidence["Testing"] == "25% test file ratio"
-    assert skill_evidence["Documentation"] == "documentation score 80.0/100"
+    assert skill_evidence["Documentation"] == "documentation score 80/100"
     assert skill_evidence["Collaboration"] == "42.0% contribution share"
     assert skill_evidence["Code Ownership"] == "1,500 LOC maintained"
 


### PR DESCRIPTION
## 📝 Description

This PR adds a few fixes to skill and framework detection, as well as documentation score calculation.

## Fixes Made
1. Fixed documentation score displaying as 0.5/100 instead of 50/100. Rewrote scoring as a composite of README presence, README quality, and comment ratio.
2. Fixed framework/skill false positives. Patterns now scoped to their relevant dep file types (JS patterns only on package.json, etc.); Unity/Unreal moved to config-file detection only; lock files excluded from framework detection.
3. Fixed duplicate skills in UI (frameworks and skills_used were being concatenated without deduplication).
4. Added missing dep files (Cargo.toml, Gemfile, pubspec.yaml, CMakeLists.txt, .csproj etc.) and ignored dirs (renv/, packrat/).
5. Taxonomy cleanup: removed noise (Babel, ESLint, Prettier, NPM, Yarn, etc.), added Tailwind, Bootstrap, Redux, Hibernate, Rails, Flutter.
6. Fixed test framework proficiency scoring reading Python-only stats for JUnit/Jest/Cypress.



**Closes:** #509 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Upload some projects and verify the correct assignment of skills and frameworks, and that the new documentation score feels fair.

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

