### PR TITLE
Update usage section to specify CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ No environment variables are required for local development. The backend uses a 
 
 ---
 
-## Usage
+## CLI Usage (skip if using the React app)
 
 To start the application, run the `main` module from the root directory.
 


### PR DESCRIPTION
Just slightly changed the wording so that it was clear that you dont also have to run the CLI after starting the front/back for the React app